### PR TITLE
Add Cypress form validation UI test (#4)

### DIFF
--- a/cypress-portfolio/cypress/e2e/form_validation_test.cy.js
+++ b/cypress-portfolio/cypress/e2e/form_validation_test.cy.js
@@ -1,0 +1,33 @@
+const URL = "https://example.cypress.io/commands/actions";
+
+describe("Form-style validation on Actions page", () => {
+  beforeEach(() => {
+    cy.visit(URL);
+  });
+
+  it("shows the email field and it is empty by default", () => {
+    cy.get(".action-email").should("be.visible").and("have.value", "");
+  });
+
+  it("treats an invalid email format as invalid via HTML5 validation", () => {
+    cy.get(".action-email").as("emailInput");
+
+    cy.get("@emailInput").clear().type("not-a-valid-email");
+
+    cy.get("@emailInput").then(($input) => {
+      const input = $input[0];
+      // Native browser validity check for obviously bad email
+      expect(input.checkValidity()).to.eq(false);
+    });
+  });
+
+  it("accepts a valid email string and updates the field value", () => {
+    cy.get(".action-email").as("emailInput");
+
+    const validEmail = "test@example.com";
+
+    cy.get("@emailInput").clear().type(validEmail);
+
+    cy.get("@emailInput").invoke("val").should("eq", validEmail);
+  });
+});


### PR DESCRIPTION
This PR adds a completed Cypress UI test for the email validation flow on the Actions page.

### Completed Work
- Added `form_validation_test.cy.js`
- Added empty, invalid, and valid email input scenarios
- Updated assertion logic for realistic validation behavior
- Included comments for readability and test structure clarity

Closes #4
