### PR TITLE
Improve Cypress API test assertions

### DIFF
--- a/cypress-portfolio/cypress/e2e/api_test.cy.js
+++ b/cypress-portfolio/cypress/e2e/api_test.cy.js
@@ -3,20 +3,37 @@ describe("Public API Tests", () => {
     cy.request("https://jsonplaceholder.typicode.com/posts/1").then(
       (response) => {
         expect(response.status).to.eq(200);
-        expect(response.body).to.have.property("id", 1);
-        expect(response.body).to.have.property("title");
-      }
+
+        expect(response.body).to.include({
+          id: 1,
+          userId: 1,
+        });
+
+        expect(response.body.title).to.be.a("string").and.not.be.empty;
+        expect(response.body.body).to.be.a("string").and.not.be.empty;
+      },
     );
   });
 
-  it("creates a new resource with POST request", () => {
-    cy.request("POST", "https://jsonplaceholder.typicode.com/posts", {
-      title: "Cypress Portfolio Test",
-      body: "This is a sample post created by Cypress.",
-      userId: 1,
+  it("creates a new resource with a POST request", () => {
+    cy.request({
+      method: "POST",
+      url: "https://jsonplaceholder.typicode.com/posts",
+      body: {
+        title: "Cypress Portfolio Test",
+        body: "This is a sample post created by Cypress.",
+        userId: 1,
+      },
     }).then((response) => {
       expect(response.status).to.eq(201);
-      expect(response.body).to.have.property("title", "Cypress Portfolio Test");
+
+      expect(response.body).to.include({
+        title: "Cypress Portfolio Test",
+        body: "This is a sample post created by Cypress.",
+        userId: 1,
+      });
+
+      expect(response.body.id).to.exist;
     });
   });
 });


### PR DESCRIPTION
## Summary

Improves the Cypress API test coverage for the JSONPlaceholder public API. This update makes the assertions more complete and easier to read for portfolio review.

## Changes

List the key changes included in this PR.

- Updated the GET request test to validate `id`, `userId`, `title`, and `body`
- Updated the POST request test to use the object-based `cy.request()` syntax
- Added stronger response body assertions for created resources

## Testing

Explain how you tested your changes.

- [x] Ran Cypress tests locally
- [x] Added new test coverage
- [x] Updated existing tests if needed

Test command used:

npm run cy:run -- --spec "cypress/e2e/api_test.cy.js"

Results for `cypress-portfolio/cypress/e2e/api_test.cy.js`
All specs passed
2 tests passing
0 failing


## Checklist

- [x] PR title follows naming conventions
- [x] Code changes are scoped to one logical task
- [x] Labels added (example: `cypress`, `jmeter`, `sql`, `playwright`)
- [x] Comments added where helpful
- [x] No debugging code left behind (console.logs, unused code)
